### PR TITLE
Bump & relax dependencies; bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinde-python-sdk"
-version = "1.2.3"
+version = "1.2.4"
 authors = [
     { name = "Kinde Engineering", email = "engineering@kinde.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,17 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "urllib3 ~=2.0.3",
-    "python-dateutil ~=2.8.2",
-    "Authlib ~=1.2.0",
+    "urllib3 ~=2.2.1",
+    "python-dateutil ~=2.9.0.post0",
+    "Authlib ~=1.3.0",
     "pyjwt ~=2.8.0",
     "requests ~=2.31.0",
-    "typing-extensions ~=4.8.0",
-    "frozendict ~=2.3.8",
-    "certifi ~=2022.12.7",
+    "typing-extensions ~=4.11.0",
+    "frozendict ~=2.4.3",
+    "certifi ~=2024.2.2",
 ]
 [project.urls]
 "Homepage" = "https://github.com/kinde-oss/kinde-python-sdk"
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-urllib3==2.0.3  # https://github.com/urllib3/urllib3
-python-dateutil==2.8.2  # https://github.com/dateutil/dateutil
-Authlib==1.2.0  # https://github.com/lepture/authlib
-pyjwt==2.8.0  # https://github.com/jpadilla/pyjwt
-requests==2.31.0 # https://github.com/psf/requests
-typing-extensions==4.8.0 # https://github.com/python/typing_extensions
-frozendict==2.3.8 # https://github.com/Marco-Sulla/python-frozendict
-certifi==2022.12.7 # https://github.com/certifi/python-certifi
+urllib3~=2.2.1  # https://github.com/urllib3/urllib3
+python-dateutil~=2.9.0.post0 # https://github.com/dateutil/dateutil
+Authlib~=1.3.0 # https://github.com/lepture/authlib
+pyjwt~=2.8.0  # https://github.com/jpadilla/pyjwt
+requests~=2.31.0 # https://github.com/psf/requests
+typing-extensions~=4.11.0 # https://github.com/python/typing_extensions
+frozendict~=2.4.3 # https://github.com/Marco-Sulla/python-frozendict
+certifi~=2024.2.2 # https://github.com/certifi/python-certifi
 


### PR DESCRIPTION
# Explain your changes

Addresses several dependency versions with security vulnerabilities (urllib3==2.0.3, certifi==2022.12.7). Additionally, bumps and relaxes dependency versions to be more friendly to other dependency installers. 

Handles #37 , #39 
# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).