### PR TITLE
Restrict maximum version of typing-extensions to <4.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "Authlib",
     "pyjwt",
     "requests",
-    "typing-extensions >=4.11.0",
+    "typing-extensions >=4.11.0, <4.14",
     "frozendict >=2.4.3",
     "certifi >=2024.7.4",
 ]


### PR DESCRIPTION
This project is not compatible with 4.14 of typing-extensions

# Explain your changes

Version 4.14 of typing-extensions causes the following error.

```python
    from kinde_sdk.api_client import ApiClient
  File "/Users/thomasdempster/Library/Caches/pypoetry/virtualenvs/prosebit-Yq8YffEh-py3.12/lib/python3.12/site-packages/kinde_sdk/api_client.py", line 1262, in <module>
    class Api:
  File "/Users/thomasdempster/Library/Caches/pypoetry/virtualenvs/prosebit-Yq8YffEh-py3.12/lib/python3.12/site-packages/kinde_sdk/api_client.py", line 1275, in Api
    def _verify_typed_dict_inputs_oapg(cls: typing.Type[typing_extensions.TypedDict], data: typing.Dict[str, typing.Any]):
                                            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thomasdempster/.pyenv/versions/3.12.10/lib/python3.12/typing.py", line 398, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/thomasdempster/.pyenv/versions/3.12.10/lib/python3.12/typing.py", line 1481, in __getitem__
    params = tuple(_type_check(p, msg) for p in params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/thomasdempster/.pyenv/versions/3.12.10/lib/python3.12/typing.py", line 1481, in <genexpr>
    params = tuple(_type_check(p, msg) for p in params)
                   ^^^^^^^^^^^^^^^^^^^
  File "/Users/thomasdempster/.pyenv/versions/3.12.10/lib/python3.12/typing.py", line 202, in _type_check
    raise TypeError(f"Plain {arg} is not valid as type argument")
TypeError: Plain typing_extensions.TypedDict is not valid as type argument
```

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
