### PR TITLE
fix token byte issue

### DIFF
--- a/kinde_sdk/kinde_api_client.py
+++ b/kinde_sdk/kinde_api_client.py
@@ -342,8 +342,8 @@ class KindeApiClient(ApiClient):
         if isinstance(token, bytes):
             try:
                 token = token.decode('utf-8')
-            except UnicodeDecodeError:
-                raise KindeTokenException(f"Token {token_name} contains invalid UTF-8 bytes.")
+            except UnicodeDecodeError as err:
+                raise KindeTokenException(f"Token {token_name} contains invalid UTF-8 bytes.") from err
         
         if not isinstance(token, str):
             return token_value

--- a/kinde_sdk/kinde_api_client.py
+++ b/kinde_sdk/kinde_api_client.py
@@ -338,16 +338,23 @@ class KindeApiClient(ApiClient):
     def _decode_token_if_needed_value(self, token_name: str, token_value: dict) -> dict:
         token = token_value.get(token_name)
 
+      
+        if isinstance(token, bytes):
+            try:
+                token = token.decode('utf-8')
+            except UnicodeDecodeError:
+                raise KindeTokenException(f"Token {token_name} contains invalid UTF-8 bytes.")
+        
         if not isinstance(token, str):
             return token_value
 
         signing_key = self.jwks_client.get_signing_key_from_jwt(token)
         if signing_key:
             decode_token_params = {
-                "jwt":token,
+                "jwt": token,
                 "key": signing_key.key,
-                "algorithms":["RS256"],
-                "options":{
+                "algorithms": ["RS256"],
+                "options": {
                     "verify_signature": True,
                     "verify_exp": True,
                     "verify_aud": False


### PR DESCRIPTION
# Fix: Restore backward compatibility for bytes tokens

## Problem
Version 1.2.8 broke backward compatibility by rejecting `bytes` tokens in `*_token` methods like `get_user_details_token()`. Code that previously worked with bytes tokens now fails.

## Fix
Modified `_decode_token_if_needed_value()` to automatically convert `bytes` to `str` before JWT processing:

```python
if isinstance(token, bytes):
    try:
        token = token.decode('utf-8')
     except UnicodeDecodeError as err:
              raise KindeTokenException(f"Token {token_name} contains invalid UTF-8 bytes.") from err
```