### PR TITLE
feat(management): add introspection logic and token management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to the Kinde Python SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.9] - 2024-12-19
+
+### Fixed
+- **OAuth2 Introspection Authentication**: Fixed `validate_and_set_via_introspection` method to use Bearer token authentication instead of client credentials for the introspection endpoint. This resolves 401 Unauthorized errors when validating bearer tokens.
+- **Token Expiration Handling**: Fixed edge case in `set_tokens` method where `expires_in=0` was being treated as `None` and defaulting to 3600 seconds. Now properly handles zero expiration values.
+- **Exception Handling**: Improved exception handling in introspection method with proper exception chaining for better error reporting and debugging.
+
+### Improved
+- **Code Quality**: Simplified expiration calculation in introspection method using conditional expression for cleaner code.
+- **Test Coverage**: Added comprehensive unit tests for the `validate_and_set_via_introspection` method covering success cases, error scenarios, edge cases, and thread safety.
+- **Documentation**: Fixed logging in FastAPI example to correctly access `UsersResponse` object properties.
+
+### Technical Details
+- The introspection method now first obtains a management token using client credentials, then uses that token to authenticate the introspection request with Bearer authentication
+- Added proper timeout handling (30 seconds) for introspection requests
+- Improved thread safety with proper locking mechanisms
+- Enhanced error messages for better debugging
+
+## [2.0.8] - Previous Release
+
+Initial release of Kinde Python SDK v2.0.x series. 

--- a/kinde_fastapi/examples/management_token_example.py
+++ b/kinde_fastapi/examples/management_token_example.py
@@ -111,7 +111,7 @@ async def get_users(token_manager: ManagementTokenManager = Depends(get_manageme
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to fetch users: {str(e)}"
-        )
+        ) from e
 
 # Run the app
 if __name__ == "__main__":

--- a/kinde_fastapi/examples/management_token_example.py
+++ b/kinde_fastapi/examples/management_token_example.py
@@ -1,0 +1,119 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import os
+import requests
+from dotenv import load_dotenv
+from kinde_sdk.management.management_token_manager import ManagementTokenManager
+from kinde_sdk.management import ManagementClient
+from typing import Dict, Any
+import time
+
+import logging
+
+# Load environment variables
+load_dotenv()
+
+# Setup logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+# Initialize FastAPI app
+app = FastAPI(title="Kinde Management Token Example with Introspection")
+
+# Security scheme for bearer token
+security = HTTPBearer()
+
+# Extract, introspect, and validate management token from header
+def get_management_token(credentials: HTTPAuthorizationCredentials = Depends(security)) -> ManagementTokenManager:
+    logger.debug("Starting token validation")
+    bearer_token = credentials.credentials
+    logger.debug(f"Received bearer token (first 20 chars): {bearer_token[:20]}...")
+    
+    # SDK config from env
+    domain = os.getenv("KINDE_HOST", "https://app.kinde.com")
+    logger.debug(f"Raw domain from env: {domain}")
+    if domain.startswith(('http://', 'https://')):
+        domain = domain.split('://', 1)[1]
+    logger.debug(f"Normalized domain: {domain}")
+    client_id = os.getenv("KINDE_MANAGEMENT_CLIENT_ID")
+    client_secret = os.getenv("KINDE_MANAGEMENT_CLIENT_SECRET")
+    logger.debug(f"Client ID: {client_id}")
+    # Not logging secret for security
+    
+    if not all([domain, client_id, client_secret]):
+        logger.error("Missing Kinde management credentials")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Missing Kinde management credentials in environment"
+        )
+    
+    try:
+        token_manager = ManagementTokenManager(
+            domain=domain,
+            client_id=client_id,
+            client_secret=client_secret
+        )
+        logger.debug(f"ManagementTokenManager instantiated {bearer_token}")
+        
+        introspection_result = token_manager.validate_and_set_via_introspection(bearer_token)
+        logger.debug(f"Introspection result: {introspection_result}")
+        
+        access_token = token_manager.get_access_token()
+        if not access_token:
+            logger.error("No access token after introspection")
+            raise ValueError("Invalid management token after introspection")
+        logger.debug("Access token obtained successfully")
+        
+        return token_manager
+    
+    except ValueError as e:
+        logger.error(f"ValueError in token validation: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(e),
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+    except Exception as e:
+        logger.error(f"Exception in token validation: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Token introspection failed: {str(e)}",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+
+# Example route using the validated management token
+@app.get("/management/users")
+async def get_users(token_manager: ManagementTokenManager = Depends(get_management_token)):
+    logger.debug("Entering get_users endpoint")
+    try:
+        # Create ManagementClient with the token manager
+        management_client = ManagementClient(
+            domain=token_manager.domain,
+            client_id=token_manager.client_id,
+            client_secret=token_manager.client_secret
+        )
+        logger.debug("ManagementClient created")
+        
+        # Fetch users (example API call)
+        users_response = management_client.get_users()
+        
+        # Get the user count from the response
+        user_count = len(users_response.users) if users_response.users else 0
+        logger.debug(f"Fetched {user_count} users")
+        
+        return {
+            "message": "Users fetched successfully",
+            "user_count": user_count,
+            "users": users_response.users if users_response.users else []  # In production, filter sensitive data
+        }
+    except Exception as e:
+        logger.error(f"Error in get_users: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to fetch users: {str(e)}"
+        )
+
+# Run the app
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000) 

--- a/kinde_sdk/management/management_token_manager.py
+++ b/kinde_sdk/management/management_token_manager.py
@@ -271,3 +271,55 @@ class ManagementTokenManager:
         """ Clear stored tokens. """
         with self.lock:
             self.tokens = {}
+
+    def validate_and_set_via_introspection(self, bearer_token: str) -> Dict[str, Any]:
+        """
+        Validate a bearer token via introspection and set it if valid.
+        
+        Args:
+            bearer_token: The bearer token to introspect and validate.
+        
+        Returns:
+            Dict: The introspection result if valid.
+        
+        Raises:
+            Exception: If introspection fails or token is invalid.
+        """
+        # First, get a management token using client credentials
+        management_token = self.get_access_token()
+        
+        introspection_url = f"https://{self.domain}/oauth2/introspect"
+        introspect_data = {
+            "token": bearer_token
+        }
+        
+        try:
+            response = requests.post(
+                introspection_url, 
+                data=introspect_data,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Authorization": f"Bearer {management_token}",
+                    "Kinde-SDK": self._generate_tracking_header()
+                },
+                timeout=30
+            )
+            response.raise_for_status()
+            introspection_result = response.json()
+            
+            if not introspection_result.get("active", False):
+                raise ValueError("Token is inactive or invalid")
+            
+            # Set the validated token
+            token_data = {
+                "access_token": bearer_token,
+                "expires_in": introspection_result.get("exp", int(time.time()) + 3600) - int(time.time())
+            }
+            self.set_tokens(token_data)
+            
+            return introspection_result
+            
+        except requests.exceptions.Timeout:
+            raise Exception(f"Introspection request timed out after 30 seconds for domain {self.domain}")
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Introspection request failed for domain {self.domain}: {str(e)}")

--- a/kinde_sdk/management/management_token_manager.py
+++ b/kinde_sdk/management/management_token_manager.py
@@ -312,10 +312,7 @@ class ManagementTokenManager:
             
             # Set the validated token - calculate proper expiration
             exp_time = introspection_result.get("exp")
-            if exp_time:
-                expires_in = max(0, exp_time - int(time.time()))
-            else:
-                expires_in = 3600  # Default 1 hour if no exp claim
+            expires_in = max(0, exp_time - int(time.time())) if exp_time else 3600
             
             token_data = {
                 "access_token": bearer_token,

--- a/kinde_sdk/management/management_token_manager.py
+++ b/kinde_sdk/management/management_token_manager.py
@@ -209,13 +209,15 @@ class ManagementTokenManager:
     def set_tokens(self, token_data: Dict[str, Any]):
         """ Store tokens with expiration. """
         with self.lock:
-            # Handle None values by using default
-            expires_in = token_data.get("expires_in") or 3600
+            # Handle None values by using default, but allow 0
+            expires_in = token_data.get("expires_in")
+            if expires_in is None:
+                expires_in = 3600
             token_type = token_data.get("token_type") or "Bearer"
             self.tokens = {
-            "access_token": token_data.get("access_token"),
-            "expires_at": time.time() + expires_in,
-            "token_type": token_type
+                "access_token": token_data.get("access_token"),
+                "expires_at": time.time() + expires_in,
+                "token_type": token_type
             }
 
     def get_access_token(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kinde-python-sdk"
-version = "2.0.8"
+version = "2.0.9"
 authors = [
     { name = "Kinde Engineering", email = "engineering@kinde.com" },
 ]


### PR DESCRIPTION
# Explain your changes

- Implement introspection logic in management token manager
- Add management token example demonstrating usage
- Update FastAPI example app with introspection capabilities
- Enhance token validation and processing workflows

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
