### PR TITLE
fix: correct users get/update/delete to `/api/v1/user?id=...`

### DIFF
--- a/kinde_sdk/management/management_client.py
+++ b/kinde_sdk/management/management_client.py
@@ -28,10 +28,10 @@ class ManagementClient:
         # Users API
         'users': {
             'list': ('GET', '/api/v1/users'),
-            'get': ('GET', '/api/v1/users/{user_id}'),
+            'get': ('GET', '/api/v1/user?id={user_id}'),
             'create': ('POST', '/api/v1/user'),
-            'update': ('PATCH', '/api/v1/users/{user_id}'),
-            'delete': ('DELETE', '/api/v1/users/{user_id}'),
+            'update': ('PATCH', '/api/v1/user?id={user_id}'),
+            'delete': ('DELETE', '/api/v1/user?id={user_id}'),
         },
         
         # Organizations API


### PR DESCRIPTION
# Explain your changes

This PR updates the `ManagementClient` to align the users `get`, `update`, and `delete` endpoints with the Management API spec:

- Uses `/api/v1/user?id={id}` instead of `/api/v1/users/{user_id}`
- Prevents 404 errors when retrieving, updating, or deleting a user
- Keeps list and sub-resource endpoints unchanged

Fixes #89

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
