### PR TITLE
feat: enhance null framework for standalone OAuth usage

### DIFF
--- a/examples/simple_http_oauth_server.py
+++ b/examples/simple_http_oauth_server.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""
+Simple HTTP OAuth Server for Local Testing
+
+This is a minimal HTTP server that demonstrates the Kinde OAuth flow
+without any framework dependencies. It's perfect for local testing
+and development.
+
+Features:
+- Simple HTTP server using Python's built-in http.server
+- OAuth login/logout flows
+- Session management using in-memory storage
+- No external dependencies beyond the Kinde SDK
+- Easy to run and test locally
+- Automatically loads .env file if present
+
+Usage:
+1. Create a .env file with your Kinde credentials (or set environment variables)
+2. Run: python simple_http_oauth_server.py
+3. Open http://localhost:5000 in your browser
+4. Test the OAuth flow
+
+Environment Variables (can be in .env file or environment):
+- KINDE_CLIENT_ID: Your Kinde application client ID
+- KINDE_CLIENT_SECRET: Your Kinde application client secret
+- KINDE_REDIRECT_URI: http://localhost:5000/callback
+- KINDE_HOST: Your Kinde domain (e.g., https://your-domain.kinde.com)
+- KINDE_AUDIENCE: Your API audience (optional)
+
+Note on OAuth Methods:
+This example now uses the proper login() and register() methods which have been
+updated to work without framework dependencies. The SDK now supports both:
+- Framework-based usage (Flask, FastAPI) - automatic session management
+- Standalone usage (serverless, Lambda) - manual session management
+"""
+
+import os
+import json
+import asyncio
+import uuid
+import urllib.parse
+import logging
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Dict, Any, Optional
+from pathlib import Path
+
+# Try to load python-dotenv if available
+try:
+    from dotenv import load_dotenv
+    env_path = Path(__file__).parent.parent / '.env'
+    if env_path.exists():
+        load_dotenv(env_path)
+        print(f"✅ Loaded .env file from: {env_path}")
+    else:
+        # Also try loading from current directory
+        current_env = Path('.env')
+        if current_env.exists():
+            load_dotenv(current_env)
+            print(f"✅ Loaded .env file from: {current_env.absolute()}")
+except ImportError:
+    print("⚠️  python-dotenv not installed. Install with: pip install python-dotenv")
+
+# Import the Kinde SDK
+from kinde_sdk import AsyncOAuth
+from kinde_sdk.core.exceptions import KindeConfigurationException
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class SimpleOAuthManager:
+    """
+    Simple OAuth manager for local testing.
+    Uses the null framework for session management.
+    """
+    
+    def __init__(self):
+        """Initialize the OAuth manager."""
+        self.client_id = os.getenv("KINDE_CLIENT_ID")
+        self.client_secret = os.getenv("KINDE_CLIENT_SECRET")
+        self.redirect_uri = os.getenv("KINDE_REDIRECT_URI", "http://localhost:5000/callback")
+        self.host = os.getenv("KINDE_HOST", "https://app.kinde.com")
+        self.audience = os.getenv("KINDE_AUDIENCE")
+        
+        # Validate required configurations
+        if not self.client_id:
+            raise KindeConfigurationException("KINDE_CLIENT_ID environment variable is required")
+        
+        # Initialize OAuth client without framework (will use null framework)
+        self.oauth = AsyncOAuth(
+            framework=None,  # Will use null framework
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            redirect_uri=self.redirect_uri,
+            host=self.host,
+            audience=self.audience
+        )
+        
+        # Get the null framework instance (singleton)
+        from kinde_sdk.core.framework.null_framework import NullFramework
+        self.null_framework = NullFramework()
+        
+        logger.info("Simple OAuth manager initialized successfully")
+    
+    def create_session(self) -> str:
+        """Create a new session."""
+        session_id = str(uuid.uuid4())
+        return session_id
+    
+    async def generate_login_url(self, session_id: str) -> str:
+        """Generate a login URL."""
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Use the standard login() method - it will get user_id from the null framework
+        login_url = await self.oauth.login()
+        
+        return login_url
+    
+    async def generate_register_url(self, session_id: str) -> str:
+        """Generate a registration URL."""
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Use the standard register() method - it will get user_id from the null framework
+        register_url = await self.oauth.register()
+        
+        return register_url
+    
+    async def handle_callback(self, session_id: str, code: str, state: Optional[str] = None) -> Dict[str, Any]:
+        """Handle OAuth callback."""
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Handle the redirect using the standard method
+        result = await self.oauth.handle_redirect(
+            code=code,
+            user_id=session_id,
+            state=state
+        )
+        
+        return result
+    
+    def is_authenticated(self, session_id: str) -> bool:
+        """Check if session is authenticated."""
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Use the standard is_authenticated method
+        return self.oauth.is_authenticated()
+    
+    def get_user_info(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Get user information."""
+        if not self.is_authenticated(session_id):
+            return None
+        
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Use the standard get_user_info method
+        try:
+            return self.oauth.get_user_info()
+        except Exception as e:
+            logger.error(f"Failed to get user info: {e}")
+            return None
+    
+    async def generate_logout_url(self, session_id: str) -> str:
+        """Generate logout URL."""
+        # Set the current user session in the null framework
+        self.null_framework.set_user_id(session_id)
+        
+        # Use the standard logout method
+        logout_url = await self.oauth.logout(user_id=session_id)
+        
+        # Clear the session from the null framework
+        self.null_framework.clear_user_id()
+        
+        logger.info(f"Generated logout URL and cleared session {session_id}")
+        return logout_url
+
+
+# Global OAuth manager
+oauth_manager = None
+
+def get_oauth_manager() -> SimpleOAuthManager:
+    """Get or create OAuth manager."""
+    global oauth_manager
+    if oauth_manager is None:
+        oauth_manager = SimpleOAuthManager()
+    return oauth_manager
+
+
+class OAuthHTTPRequestHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for OAuth operations."""
+    
+    def do_GET(self):
+        """Handle GET requests."""
+        try:
+            # Parse URL and query parameters
+            parsed_url = urllib.parse.urlparse(self.path)
+            path = parsed_url.path
+            query_params = urllib.parse.parse_qs(parsed_url.query)
+            
+            # Flatten query parameters (parse_qs returns lists)
+            params = {k: v[0] if v else None for k, v in query_params.items()}
+            
+            logger.info(f"GET {path} - Params: {params}")
+            
+            if path == '/':
+                self._handle_home()
+            elif path == '/login':
+                self._handle_login(params)
+            elif path == '/register':
+                self._handle_register(params)
+            elif path == '/callback':
+                self._handle_callback(params)
+            elif path == '/user':
+                self._handle_user(params)
+            elif path == '/logout':
+                self._handle_logout(params)
+            else:
+                self._handle_not_found()
+                
+        except Exception as e:
+            logger.error(f"Error handling request: {e}")
+            self._send_error_response(500, f"Internal server error: {str(e)}")
+    
+    def _handle_home(self):
+        """Handle home page."""
+        html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Kinde OAuth Test Server</title>
+            <style>
+                body { font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }
+                .button { display: inline-block; padding: 10px 20px; margin: 10px; background: #007bff; color: white; text-decoration: none; border-radius: 5px; }
+                .button:hover { background: #0056b3; }
+                .info { background: #f8f9fa; padding: 15px; border-radius: 5px; margin: 20px 0; }
+                .error { background: #f8d7da; color: #721c24; padding: 15px; border-radius: 5px; margin: 20px 0; }
+            </style>
+        </head>
+        <body>
+            <h1>🚀 Kinde OAuth Test Server</h1>
+            <p>This is a simple HTTP server for testing Kinde OAuth flows locally.</p>
+            
+            <div class="info">
+                <h3>Available Endpoints:</h3>
+                <ul>
+                    <li><a href="/login" class="button">Login</a> - Start OAuth login flow</li>
+                    <li><a href="/register" class="button">Register</a> - Start OAuth registration flow</li>
+                    <li><a href="/user" class="button">User Info</a> - View user information (requires login)</li>
+                    <li><a href="/logout" class="button">Logout</a> - Logout and clear session</li>
+                </ul>
+            </div>
+            
+            <div class="info">
+                <h3>Environment Variables Required:</h3>
+                <ul>
+                    <li><code>KINDE_CLIENT_ID</code> - Your Kinde application client ID</li>
+                    <li><code>KINDE_CLIENT_SECRET</code> - Your Kinde application client secret</li>
+                    <li><code>KINDE_REDIRECT_URI</code> - http://localhost:5000/callback</li>
+                    <li><code>KINDE_HOST</code> - Your Kinde domain</li>
+                </ul>
+            </div>
+        </body>
+        </html>
+        """
+        self._send_html_response(html)
+    
+    def _handle_login(self, params):
+        """Handle login request."""
+        try:
+            oauth = get_oauth_manager()
+            session_id = oauth.create_session()
+            login_url = asyncio.run(oauth.generate_login_url(session_id))
+            
+            # Set session cookie and redirect
+            self.send_response(302)
+            self.send_header('Location', login_url)
+            self.send_header('Set-Cookie', f'session_id={session_id}; HttpOnly; Path=/')
+            self.end_headers()
+            
+        except Exception as e:
+            self._send_error_response(500, f"Login failed: {str(e)}")
+    
+    def _handle_register(self, params):
+        """Handle registration request."""
+        try:
+            oauth = get_oauth_manager()
+            session_id = oauth.create_session()
+            register_url = asyncio.run(oauth.generate_register_url(session_id))
+            
+            # Set session cookie and redirect
+            self.send_response(302)
+            self.send_header('Location', register_url)
+            self.send_header('Set-Cookie', f'session_id={session_id}; HttpOnly; Path=/')
+            self.end_headers()
+            
+        except Exception as e:
+            self._send_error_response(500, f"Registration failed: {str(e)}")
+    
+    def _handle_callback(self, params):
+        """Handle OAuth callback."""
+        try:
+            code = params.get('code')
+            state = params.get('state')
+            
+            if not code:
+                self._send_error_response(400, "Missing authorization code")
+                return
+            
+            # Get session ID from cookie
+            session_id = self._get_session_id_from_cookie()
+            if not session_id:
+                self._send_error_response(400, "No session found")
+                return
+            
+            oauth = get_oauth_manager()
+            result = asyncio.run(oauth.handle_callback(session_id, code, state))
+            
+            # Show success page
+            user_info = result['user']
+            html = f"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>Authentication Successful</title>
+                <style>
+                    body {{ font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }}
+                    .success {{ background: #d4edda; color: #155724; padding: 15px; border-radius: 5px; margin: 20px 0; }}
+                    .user-info {{ background: #f8f9fa; padding: 15px; border-radius: 5px; margin: 20px 0; }}
+                    .button {{ display: inline-block; padding: 10px 20px; margin: 10px; background: #007bff; color: white; text-decoration: none; border-radius: 5px; }}
+                </style>
+            </head>
+            <body>
+                <h1>✅ Authentication Successful!</h1>
+                <div class="success">
+                    <p>You have successfully authenticated with Kinde.</p>
+                </div>
+                
+                <div class="user-info">
+                    <h3>User Information:</h3>
+                    <pre>{json.dumps(user_info, indent=2)}</pre>
+                </div>
+                
+                <p>
+                    <a href="/user" class="button">View User Info</a>
+                    <a href="/logout" class="button">Logout</a>
+                    <a href="/" class="button">Home</a>
+                </p>
+            </body>
+            </html>
+            """
+            self._send_html_response(html)
+            
+        except Exception as e:
+            self._send_error_response(400, f"Authentication failed: {str(e)}")
+    
+    def _handle_user(self, params):
+        """Handle user info request."""
+        try:
+            session_id = self._get_session_id_from_cookie()
+            if not session_id:
+                self._send_error_response(401, "No session found")
+                return
+            
+            oauth = get_oauth_manager()
+            if not oauth.is_authenticated(session_id):
+                self._send_error_response(401, "Not authenticated")
+                return
+            
+            user_info = oauth.get_user_info(session_id)
+            if not user_info:
+                self._send_error_response(404, "User info not found")
+                return
+            
+            html = f"""
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>User Information</title>
+                <style>
+                    body {{ font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }}
+                    .user-info {{ background: #f8f9fa; padding: 15px; border-radius: 5px; margin: 20px 0; }}
+                    .button {{ display: inline-block; padding: 10px 20px; margin: 10px; background: #007bff; color: white; text-decoration: none; border-radius: 5px; }}
+                </style>
+            </head>
+            <body>
+                <h1>👤 User Information</h1>
+                
+                <div class="user-info">
+                    <pre>{json.dumps(user_info, indent=2)}</pre>
+                </div>
+                
+                <p>
+                    <a href="/logout" class="button">Logout</a>
+                    <a href="/" class="button">Home</a>
+                </p>
+            </body>
+            </html>
+            """
+            self._send_html_response(html)
+            
+        except Exception as e:
+            self._send_error_response(500, f"Failed to get user info: {str(e)}")
+    
+    def _handle_logout(self, params):
+        """Handle logout request."""
+        try:
+            session_id = self._get_session_id_from_cookie()
+            if not session_id:
+                self._send_error_response(400, "No session found")
+                return
+            
+            oauth = get_oauth_manager()
+            logout_url = asyncio.run(oauth.generate_logout_url(session_id))
+            
+            # Clear session cookie and redirect
+            self.send_response(302)
+            self.send_header('Location', logout_url)
+            self.send_header('Set-Cookie', 'session_id=; HttpOnly; Path=/; Max-Age=0')
+            self.end_headers()
+            
+        except Exception as e:
+            self._send_error_response(500, f"Logout failed: {str(e)}")
+    
+    def _handle_not_found(self):
+        """Handle 404 errors."""
+        self._send_error_response(404, "Page not found")
+    
+    def _get_session_id_from_cookie(self) -> Optional[str]:
+        """Extract session ID from cookie."""
+        cookie_header = self.headers.get('Cookie', '')
+        for cookie in cookie_header.split(';'):
+            cookie = cookie.strip()
+            if cookie.startswith('session_id='):
+                return cookie.split('=', 1)[1]
+        return None
+    
+    def _send_html_response(self, html: str, status_code: int = 200):
+        """Send HTML response."""
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(html.encode('utf-8'))
+    
+    def _send_error_response(self, status_code: int, message: str):
+        """Send error response."""
+        html = f"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Error {status_code}</title>
+            <style>
+                body {{ font-family: Arial, sans-serif; max-width: 800px; margin: 50px auto; padding: 20px; }}
+                .error {{ background: #f8d7da; color: #721c24; padding: 15px; border-radius: 5px; margin: 20px 0; }}
+                .button {{ display: inline-block; padding: 10px 20px; margin: 10px; background: #007bff; color: white; text-decoration: none; border-radius: 5px; }}
+            </style>
+        </head>
+        <body>
+            <h1>❌ Error {status_code}</h1>
+            <div class="error">
+                <p>{message}</p>
+            </div>
+            <p><a href="/" class="button">Home</a></p>
+        </body>
+        </html>
+        """
+        self._send_html_response(html, status_code)
+    
+    def log_message(self, format, *args):
+        """Override to use our logger."""
+        logger.info(f"{self.address_string()} - {format % args}")
+
+
+def main():
+    """Main function to start the server."""
+    print("🚀 Starting Kinde OAuth Test Server")
+    print("="*50)
+    
+    # Check environment variables
+    required_vars = ["KINDE_CLIENT_ID"]
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+    
+    if missing_vars:
+        print(f"❌ Missing environment variables: {missing_vars}")
+        print("\nYou can set these in two ways:")
+        print("\n1. Create a .env file in the project root with:")
+        print("   KINDE_CLIENT_ID=your_client_id")
+        print("   KINDE_CLIENT_SECRET=your_client_secret")
+        print("   KINDE_REDIRECT_URI=http://localhost:5000/callback")
+        print("   KINDE_HOST=https://your-domain.kinde.com")
+        print("   KINDE_AUDIENCE=your_api_audience  # Optional")
+        print("\n2. Or set environment variables:")
+        print("   export KINDE_CLIENT_ID=your_client_id")
+        print("   export KINDE_CLIENT_SECRET=your_client_secret")
+        print("   export KINDE_REDIRECT_URI=http://localhost:5000/callback")
+        print("   export KINDE_HOST=https://your-domain.kinde.com")
+        print("   export KINDE_AUDIENCE=your_api_audience  # Optional")
+        print("\nThen run: python simple_http_oauth_server.py")
+        return
+    
+    try:
+        # Test OAuth manager initialization
+        oauth = get_oauth_manager()
+        print("✅ OAuth manager initialized successfully")
+        
+        # Start HTTP server
+        server_address = ('localhost', 5000)
+        httpd = HTTPServer(server_address, OAuthHTTPRequestHandler)
+        
+        print(f"🌐 Server running at http://localhost:5000")
+        print("📋 Available endpoints:")
+        print("   GET / - Home page with instructions")
+        print("   GET /login - Start OAuth login flow")
+        print("   GET /register - Start OAuth registration flow")
+        print("   GET /callback - OAuth callback (handled automatically)")
+        print("   GET /user - View user information")
+        print("   GET /logout - Logout and clear session")
+        print("\n🔧 Environment variables:")
+        print(f"   KINDE_CLIENT_ID: {os.getenv('KINDE_CLIENT_ID', 'Not set')}")
+        print(f"   KINDE_REDIRECT_URI: {os.getenv('KINDE_REDIRECT_URI', 'http://localhost:5000/callback')}")
+        print(f"   KINDE_HOST: {os.getenv('KINDE_HOST', 'https://app.kinde.com')}")
+        print(f"   KINDE_AUDIENCE: {os.getenv('KINDE_AUDIENCE', 'Not set')}")
+        print("\n⏹️  Press Ctrl+C to stop the server")
+        
+        # Start the server
+        httpd.serve_forever()
+        
+    except KeyboardInterrupt:
+        print("\n⏹️  Server stopped by user")
+    except Exception as e:
+        print(f"❌ Server error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kinde_sdk/auth/__init__.py
+++ b/kinde_sdk/auth/__init__.py
@@ -4,9 +4,10 @@ from .user_session import UserSession
 from .api_options import ApiOptions
 from .permissions import permissions
 from .claims import claims
+from .async_claims import async_claims
 from .feature_flags import feature_flags
 from .portals import portals
 from .tokens import tokens
 from .roles import roles
 
-__all__ = ["OAuth", "TokenManager", "UserSession", "permissions", "ApiOptions", "claims", "feature_flags", "portals", "tokens", "roles"]
+__all__ = ["OAuth", "TokenManager", "UserSession", "permissions", "ApiOptions", "claims", "async_claims", "feature_flags", "portals", "tokens", "roles"]

--- a/kinde_sdk/auth/oauth.py
+++ b/kinde_sdk/auth/oauth.py
@@ -80,9 +80,8 @@ class OAuth:
         if framework:
             self._initialize_framework()
         else:
-            # Use configuration-based storage if no framework specified
-            self._storage = StorageFactory.create_storage(storage_config)
-            self._storage_manager.initialize(config=storage_config, storage=self._storage)
+            # Use null framework for standalone usage
+            self._initialize_null_framework(storage_config)
 
         self._session_manager = UserSession()
 
@@ -123,6 +122,28 @@ class OAuth:
         
         # Initialize storage manager with the framework-specific storage
         self._storage_manager.initialize(config={"type": self.framework, "device_id": self._framework.get_name()}, storage=self._storage)
+
+    def _initialize_null_framework(self, storage_config: Dict[str, Any]) -> None:
+        """
+        Initialize the null framework for standalone usage.
+        This sets up the null framework and its associated storage.
+        """
+        from kinde_sdk.core.framework.null_framework import NullFramework
+        
+        # Create null framework instance (singleton)
+        self._framework = NullFramework()
+        
+        # Set the OAuth instance in the framework
+        self._framework.set_oauth(self)
+        
+        # Start the framework (no-op for null framework)
+        self._framework.start()
+        
+        # Create storage using memory storage for standalone usage
+        self._storage = StorageFactory.create_storage(storage_config)
+        
+        # Initialize storage manager with the null framework storage
+        self._storage_manager.initialize(config={"type": "null", "device_id": self._framework.get_name()}, storage=self._storage)
 
     def is_authenticated(self) -> bool:
         """
@@ -365,8 +386,7 @@ class OAuth:
         Returns:
             Login URL
         """
-        if not self.framework:
-            raise KindeConfigurationException("Framework must be selected")
+        # Framework check removed - null framework is now supported
         
         if login_options is None:
             login_options = {}
@@ -407,8 +427,7 @@ class OAuth:
         Returns:
             Registration URL
         """
-        if not self.framework:
-            raise KindeConfigurationException("Framework must be selected")
+        # Framework check removed - null framework is now supported
 
         if login_options is None:
             login_options = {}
@@ -440,8 +459,7 @@ class OAuth:
         Returns:
             Logout URL
         """
-        if not self.framework:
-            raise KindeConfigurationException("Framework must be selected")
+        # Framework check removed - null framework is now supported
 
         if logout_options is None:
             logout_options = {}

--- a/testv2/testv2_core/test_null_framework.py
+++ b/testv2/testv2_core/test_null_framework.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+Test suite for the NullFramework implementation.
+
+This test suite verifies:
+1. Singleton pattern functionality
+2. User ID management (set, get, clear)
+3. Thread safety with threading.Thread
+4. Async safety with asyncio
+5. Framework interface compliance
+6. Integration with OAuth class
+"""
+
+import unittest
+import threading
+import asyncio
+import uuid
+from unittest.mock import Mock, patch
+from kinde_sdk.core.framework.null_framework import NullFramework
+from kinde_sdk import OAuth
+
+
+class TestNullFramework(unittest.TestCase):
+    """Test cases for NullFramework class."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        # Clear any existing singleton instance for clean tests
+        NullFramework._instance = None
+    
+    def tearDown(self):
+        """Clean up after tests."""
+        # Clear singleton instance
+        NullFramework._instance = None
+    
+    def test_singleton_pattern(self):
+        """Test that NullFramework implements singleton pattern correctly."""
+        # Create two instances
+        instance1 = NullFramework()
+        instance2 = NullFramework()
+        
+        # They should be the same instance
+        self.assertIs(instance1, instance2)
+        self.assertEqual(id(instance1), id(instance2))
+    
+    def test_framework_properties(self):
+        """Test framework name and description."""
+        framework = NullFramework()
+        
+        self.assertEqual(framework.get_name(), "null")
+        self.assertIn("session management", framework.get_description().lower())
+        self.assertIn("standalone", framework.get_description().lower())
+    
+    def test_framework_interface_compliance(self):
+        """Test that NullFramework implements all required interface methods."""
+        framework = NullFramework()
+        
+        # Test all abstract methods from FrameworkInterface
+        self.assertIsNotNone(framework.get_name())
+        self.assertIsNotNone(framework.get_description())
+        
+        # These should not raise exceptions
+        framework.start()
+        framework.stop()
+        
+        # These should return None for null framework
+        self.assertIsNone(framework.get_app())
+        self.assertIsNone(framework.get_request())
+        self.assertFalse(framework.can_auto_detect())
+    
+    def test_user_id_management(self):
+        """Test user ID set, get, and clear operations."""
+        framework = NullFramework()
+        
+        # Initially should be None
+        self.assertIsNone(framework.get_user_id())
+        
+        # Set user ID
+        test_user_id = "test-user-123"
+        framework.set_user_id(test_user_id)
+        self.assertEqual(framework.get_user_id(), test_user_id)
+        
+        # Clear user ID
+        framework.clear_user_id()
+        self.assertIsNone(framework.get_user_id())
+    
+    def test_user_id_persistence(self):
+        """Test that user ID persists across method calls."""
+        framework = NullFramework()
+        
+        test_user_id = "persistent-user-456"
+        framework.set_user_id(test_user_id)
+        
+        # Call other methods and verify user ID is still there
+        framework.get_name()
+        framework.get_description()
+        framework.start()
+        framework.stop()
+        
+        self.assertEqual(framework.get_user_id(), test_user_id)
+    
+    def test_oauth_integration(self):
+        """Test setting and getting OAuth instance."""
+        framework = NullFramework()
+        mock_oauth = Mock()
+        
+        # Initially should be None
+        self.assertIsNone(framework._oauth)
+        
+        # Set OAuth instance
+        framework.set_oauth(mock_oauth)
+        self.assertEqual(framework._oauth, mock_oauth)
+    
+    def test_thread_safety_basic(self):
+        """Test basic thread safety with threading.Thread."""
+        framework = NullFramework()
+        results = {}
+        errors = []
+        
+        def worker_thread(thread_id: int, user_id: str):
+            """Worker thread that sets and verifies user_id."""
+            try:
+                framework.set_user_id(user_id)
+                # Small delay to increase chance of race condition
+                threading.Event().wait(0.01)
+                retrieved_user_id = framework.get_user_id()
+                
+                if retrieved_user_id == user_id:
+                    results[thread_id] = True
+                else:
+                    results[thread_id] = False
+            except Exception as e:
+                errors.append(f"Thread {thread_id}: {e}")
+        
+        # Create multiple threads with different user_ids
+        threads = []
+        user_ids = [f"thread-user-{i}-{uuid.uuid4().hex[:8]}" for i in range(5)]
+        
+        for i, user_id in enumerate(user_ids):
+            thread = threading.Thread(target=worker_thread, args=(i, user_id))
+            threads.append(thread)
+        
+        # Start all threads
+        for thread in threads:
+            thread.start()
+        
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+        
+        # Verify no errors occurred
+        self.assertEqual(len(errors), 0, f"Errors occurred: {errors}")
+        
+        # Verify all threads succeeded
+        self.assertEqual(len(results), 5)
+        self.assertTrue(all(results.values()), "Some threads failed thread safety test")
+    
+    def test_async_safety(self):
+        """Test async safety with asyncio."""
+        framework = NullFramework()
+        
+        async def async_worker(worker_id: int, user_id: str):
+            """Async worker that sets and verifies user_id."""
+            framework.set_user_id(user_id)
+            # Small delay
+            await asyncio.sleep(0.01)
+            retrieved_user_id = framework.get_user_id()
+            return retrieved_user_id == user_id
+        
+        async def run_async_test():
+            """Run multiple async workers concurrently."""
+            user_ids = [f"async-user-{i}-{uuid.uuid4().hex[:8]}" for i in range(5)]
+            tasks = [async_worker(i, user_id) for i, user_id in enumerate(user_ids)]
+            results = await asyncio.gather(*tasks)
+            return results
+        
+        # Run the async test
+        results = asyncio.run(run_async_test())
+        
+        # Verify all async workers succeeded
+        self.assertEqual(len(results), 5)
+        self.assertTrue(all(results), "Some async workers failed async safety test")
+    
+    def test_mixed_threading_async_safety(self):
+        """Test safety when mixing threading and async operations."""
+        framework = NullFramework()
+        results = {'thread': [], 'async': []}
+        
+        def thread_worker(thread_id: int):
+            """Thread worker."""
+            user_id = f"thread-{thread_id}"
+            framework.set_user_id(user_id)
+            threading.Event().wait(0.01)
+            retrieved = framework.get_user_id()
+            results['thread'].append(retrieved == user_id)
+        
+        async def async_worker(async_id: int):
+            """Async worker."""
+            user_id = f"async-{async_id}"
+            framework.set_user_id(user_id)
+            await asyncio.sleep(0.01)
+            retrieved = framework.get_user_id()
+            results['async'].append(retrieved == user_id)
+        
+        async def run_mixed_test():
+            """Run mixed threading and async test."""
+            # Start thread
+            thread = threading.Thread(target=thread_worker, args=(1,))
+            thread.start()
+            
+            # Run async worker
+            await async_worker(1)
+            
+            # Wait for thread to complete
+            thread.join()
+        
+        # Run the mixed test
+        asyncio.run(run_mixed_test())
+        
+        # Verify both thread and async operations succeeded
+        self.assertEqual(len(results['thread']), 1)
+        self.assertEqual(len(results['async']), 1)
+        self.assertTrue(results['thread'][0], "Thread operation failed")
+        self.assertTrue(results['async'][0], "Async operation failed")
+    
+    def test_context_isolation(self):
+        """Test that different contexts maintain separate user_ids."""
+        framework = NullFramework()
+        
+        # Set user_id in main context
+        framework.set_user_id("main-context")
+        self.assertEqual(framework.get_user_id(), "main-context")
+        
+        # Create new context and verify it starts with None
+        import contextvars
+        new_context = contextvars.copy_context()
+        
+        def check_context():
+            return framework.get_user_id()
+        
+        # In new context, should be None (default) because context variables
+        # are isolated between contexts. However, contextvars.copy_context()
+        # actually copies the current context, so it will inherit the current value.
+        # Let's test a different approach - creating a completely new context.
+        result = new_context.run(check_context)
+        # The copied context will have the same value as the original
+        self.assertEqual(result, "main-context")
+        
+        # Set user_id in new context
+        def set_and_check():
+            framework.set_user_id("new-context")
+            return framework.get_user_id()
+        
+        result = new_context.run(set_and_check)
+        self.assertEqual(result, "new-context")
+        
+        # Original context should still have original value
+        self.assertEqual(framework.get_user_id(), "main-context")
+
+
+class TestNullFrameworkOAuthIntegration(unittest.TestCase):
+    """Test integration between NullFramework and OAuth class."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        NullFramework._instance = None
+    
+    def tearDown(self):
+        """Clean up after tests."""
+        NullFramework._instance = None
+    
+    def test_oauth_initialization_with_null_framework(self):
+        """Test that OAuth initializes correctly with null framework."""
+        oauth = OAuth(
+            framework=None,
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8080/callback"
+        )
+        
+        # Verify null framework is used
+        self.assertIsNotNone(oauth._framework)
+        self.assertEqual(oauth._framework.get_name(), "null")
+        self.assertEqual(oauth.framework, None)  # OAuth.framework should still be None
+    
+    def test_oauth_methods_with_null_framework(self):
+        """Test that OAuth methods work with null framework."""
+        oauth = OAuth(
+            framework=None,
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8080/callback"
+        )
+        
+        # Get null framework instance
+        null_framework = NullFramework()
+        
+        # Set user_id
+        test_user_id = "test-oauth-user"
+        null_framework.set_user_id(test_user_id)
+        
+        # Test that OAuth can get user_id from null framework
+        retrieved_user_id = oauth._framework.get_user_id()
+        self.assertEqual(retrieved_user_id, test_user_id)
+    
+    @patch('kinde_sdk.auth.oauth.generate_random_string')
+    @patch('kinde_sdk.auth.oauth.generate_pkce_pair')
+    def test_oauth_login_with_null_framework(self, mock_pkce, mock_random):
+        """Test OAuth login method with null framework."""
+        # Mock the random generation functions
+        mock_random.return_value = "mocked-state-123"
+        mock_pkce.return_value = {
+            "code_verifier": "mocked-code-verifier",
+            "code_challenge": "mocked-code-challenge"
+        }
+        
+        oauth = OAuth(
+            framework=None,
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8080/callback"
+        )
+        
+        # Get null framework instance
+        null_framework = NullFramework()
+        
+        # Set user_id
+        test_user_id = "test-login-user"
+        null_framework.set_user_id(test_user_id)
+        
+        # Test login method
+        login_url = asyncio.run(oauth.login())
+        
+        # Verify URL was generated
+        self.assertIsInstance(login_url, str)
+        self.assertIn("test_client_id", login_url)
+        # The URL is URL-encoded, so we need to check for the encoded version
+        self.assertIn("http%3A%2F%2Flocalhost%3A8080%2Fcallback", login_url)
+        
+        # Verify state was stored
+        stored_state = oauth._session_manager.storage_manager.get("state")
+        self.assertIsNotNone(stored_state)
+        self.assertEqual(stored_state["value"], "mocked-state-123")
+    
+    def test_oauth_is_authenticated_with_null_framework(self):
+        """Test OAuth is_authenticated method with null framework."""
+        oauth = OAuth(
+            framework=None,
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8080/callback"
+        )
+        
+        # Get null framework instance
+        null_framework = NullFramework()
+        
+        # Initially should not be authenticated
+        null_framework.set_user_id("test-user")
+        is_auth = oauth.is_authenticated()
+        self.assertFalse(is_auth)  # No tokens stored yet
+
+
+class TestNullFrameworkEdgeCases(unittest.TestCase):
+    """Test edge cases and error conditions for NullFramework."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        NullFramework._instance = None
+    
+    def tearDown(self):
+        """Clean up after tests."""
+        NullFramework._instance = None
+    
+    def test_clear_user_id_when_not_set(self):
+        """Test clearing user_id when it was never set."""
+        framework = NullFramework()
+        
+        # Should not raise exception
+        framework.clear_user_id()
+        self.assertIsNone(framework.get_user_id())
+    
+    def test_set_none_user_id(self):
+        """Test setting None as user_id."""
+        framework = NullFramework()
+        
+        framework.set_user_id(None)
+        self.assertIsNone(framework.get_user_id())
+    
+    def test_set_empty_string_user_id(self):
+        """Test setting empty string as user_id."""
+        framework = NullFramework()
+        
+        framework.set_user_id("")
+        self.assertEqual(framework.get_user_id(), "")
+    
+    def test_multiple_set_user_id_calls(self):
+        """Test multiple set_user_id calls in same context."""
+        framework = NullFramework()
+        
+        framework.set_user_id("user-1")
+        self.assertEqual(framework.get_user_id(), "user-1")
+        
+        framework.set_user_id("user-2")
+        self.assertEqual(framework.get_user_id(), "user-2")
+        
+        framework.set_user_id("user-3")
+        self.assertEqual(framework.get_user_id(), "user-3")
+    
+    def test_concurrent_set_user_id_calls(self):
+        """Test concurrent set_user_id calls from different threads."""
+        framework = NullFramework()
+        results = []
+        
+        def worker(thread_id: int):
+            user_id = f"concurrent-user-{thread_id}"
+            framework.set_user_id(user_id)
+            # Small delay
+            threading.Event().wait(0.01)
+            retrieved = framework.get_user_id()
+            results.append(retrieved == user_id)
+        
+        # Create and start multiple threads
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(3)]
+        
+        for thread in threads:
+            thread.start()
+        
+        for thread in threads:
+            thread.join()
+        
+        # All threads should have succeeded
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(results), "Concurrent set_user_id calls failed")
+
+
+if __name__ == '__main__':
+    # Create test suite
+    test_suite = unittest.TestSuite()
+    
+    # Add test cases
+    loader = unittest.TestLoader()
+    test_suite.addTest(loader.loadTestsFromTestCase(TestNullFramework))
+    test_suite.addTest(loader.loadTestsFromTestCase(TestNullFrameworkOAuthIntegration))
+    test_suite.addTest(loader.loadTestsFromTestCase(TestNullFrameworkEdgeCases))
+    
+    # Run tests
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(test_suite)
+    
+    # Print summary
+    print(f"\n{'='*60}")
+    print(f"Test Summary:")
+    print(f"Tests run: {result.testsRun}")
+    print(f"Failures: {len(result.failures)}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Success rate: {((result.testsRun - len(result.failures) - len(result.errors)) / result.testsRun * 100):.1f}%")
+    
+    if result.failures:
+        print(f"\nFailures:")
+        for test, traceback in result.failures:
+            print(f"  - {test}: {traceback}")
+    
+    if result.errors:
+        print(f"\nErrors:")
+        for test, traceback in result.errors:
+            print(f"  - {test}: {traceback}")
+    
+    print(f"{'='*60}")
+    
+    # Exit with appropriate code
+    exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
# Explain your changes

- Refactor OAuth initialization to use null framework for standalone usage
- Transform NullFramework into singleton pattern with session management
- Add thread-safe session handling with context variables support
- Update auth module exports for better framework integration
- Add comprehensive HTTP OAuth server example
- Include comprehensive test suite for null framework functionality

This enables standalone OAuth usage without requiring a web framework, making the SDK more flexible for various application architectures.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
