### PR TITLE
chore(deps): upgrade pytest to >=9.0.3 with Python 3.9 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,9 @@ flask = [
     "flask >=3.0.0, <4.0.0",
 ]
 dev = [
-    "pytest >=7.4.0",
+    # pytest 9 requires Python >=3.10; pytest 9.0.3 fixes CVE-2025-71176
+    "pytest >=9.0.3; python_version >= '3.10'",
+    "pytest >=7.4.0,<9; python_version < '3.10'",
     "pytest-cov >=4.1.0",
     "pytest-django >=4.5.2",
     "mypy >=1.5.0",
@@ -82,7 +84,11 @@ zip-safe = false
 "kinde_flask" = ["**/*.py", "**/*.json", "**/*.yaml", "**/*.yml"]
 
 [tool.poetry.dev-dependencies]
-pytest = "^7.4.0"
+# pytest 9 requires Python >=3.10; pytest 9.0.3 fixes CVE-2025-71176
+pytest = [
+    {version = ">=7.4.0,<9", python = "~3.9"},
+    {version = "^9.0.3", python = ">=3.10"}
+]
 pytest-cov = "^7.0.0"
 coverage = ">=7.10.6"
 pytest-django = "^4.5.2"
@@ -95,4 +101,3 @@ pytest-timeout = "^2.2.0"
 black = "^26.0.0"
 flake8 = "^7.0.0"
 isort = "^8.0.0"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,10 @@ certifi>=2026.1.4
 pydantic>=2.0.0,<3.0.0
 
 # Development dependencies
-pytest>=7.4.0
+# pytest 9 requires Python >=3.10; keep <9 for Python 3.9 (pytest 9 dropped 3.9 support)
+# CVE-2025-71176 is fixed in 9.0.3 (only available for Python >=3.10)
+pytest>=9.0.3; python_version >= "3.10"
+pytest>=7.4.0,<9; python_version < "3.10"
 pytest-django>=4.5.2
 pytest-asyncio>=0.21.1
 pytest-cov>=7.0.0


### PR DESCRIPTION
## Summary

This PR upgrades `pytest` to `>=9.0.3` (for Python >=3.10) to address **CVE-2025-71176** while **preserving Python 3.9 support** - a conservative, non-breaking alternative to #169.

### Security Fix
**CVE-2025-71176** (CVSS 6.8 / Medium): pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, allowing local users to cause denial of service or gain privileges. Fixed in pytest 9.0.3.

### Why not just merge #169?
pytest 9 **dropped Python 3.9 support**. The SDK's `requires-python = ">=3.9"` and the CI matrix includes Python 3.9. Merging #169 directly would cause the Python 3.9 CI job to fail on install.

### Approach (environment-marker based constraints)

| Python version | pytest range | Rationale |
|---|---|---|
| `>=3.10` | `>=9.0.3` | Gets CVE fix, full pytest 9 feature set |
| `<3.10` (3.9) | `>=7.4.0,<9` | pytest 9 does not support Python 3.9; no CVE backport exists for 8.x |

> **Note:** Python 3.9 environments will remain on the latest pytest 8.x. The CVE has a local attack vector and affects a dev-only dependency, so the risk exposure on 3.9 is minimal.

### Files changed
- `requirements.txt` — split `pytest` into two conditional lines using pip environment markers
- `pyproject.toml` — updated both `[project.optional-dependencies].dev` (pip markers) and `[tool.poetry.dev-dependencies]` (Poetry inline-table multi-constraint syntax)

### Relates to / supersedes
Closes / supersedes renovate PR #169 (`chore(deps): update dependency pytest to v9 [security]`)"