### PR TITLE
fix(deps): upgrade pylint correctly - 4.0.5 for Python>=3.10, keep 3.x for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dev = [
     "pytest-django >=4.5.2",
     "mypy >=1.5.0",
     "bandit >=1.7",
-    "pylint >=4.0.0; python_version >= '3.10'",
-    "pylint >=3.3.0, <4.0.0; python_version < '3.10'",
+    "pylint >=4.0.5, <4.1.0; python_version >= '3.10'",
+    "pylint >=3.3.9, <4.0.0; python_version < '3.10'",
     "pycodestyle >=2.0",
     "pytest-asyncio >=0.26.0",
     "pytest-timeout >=2.2.0",
@@ -95,8 +95,8 @@ pytest-django = "^4.5.2"
 mypy = "^1.5.0"
 bandit = "^1.7"
 pylint = [
-    {version = ">=3.3.0,<4.0.0", python = "~3.9"},
-    {version = ">=4.0.0", python = ">=3.10"}
+    {version = ">=3.3.9,<4.0.0", python = "~3.9"},
+    {version = ">=4.0.5,<4.1.0", python = ">=3.10"}
 ]
 pycodestyle = "^2.0"
 pytest-asyncio = "^0.26.0"


### PR DESCRIPTION
## Summary

This PR replaces #178 (renovate bot's `renovate/pylint-4.x` branch) with a corrected pylint upgrade.

**Why #178 cannot be merged:**

pylint 4.0.5 has `requires_python >= "3.10.0"` (verified via PyPI). PR #178 pinned `pylint >=4.0.5, <4.1.0; python_version < '3.10'`, which targets Python 3.9 developers. pip would fail to resolve a compatible pylint version for Python 3.9 with that constraint, breaking `pip install -e ".[dev]"` on Python 3.9.

## Changes

| Section | Before | After |
|---|---|---|
| `[project.optional-dependencies] dev` (Python >=3.10) | `pylint >=4.0.0` | `pylint >=4.0.5, <4.1.0` |
| `[project.optional-dependencies] dev` (Python <3.10) | `pylint >=3.3.0, <4.0.0` | `pylint >=3.3.9, <4.0.0` |
| `[tool.poetry.dev-dependencies]` (Python ~3.9) | `>=3.3.0,<4.0.0` | `>=3.3.9,<4.0.0` |
| `[tool.poetry.dev-dependencies]` (Python >=3.10) | `>=4.0.0` | `>=4.0.5,<4.1.0` |

- **Python >=3.10**: upgraded to pylint 4.0.5 (latest stable 4.x, supports Python 3.10-3.14, PyPy 3.11)
- **Python 3.9**: bumped to pylint 3.3.9 (latest 3.x; pylint 4.x cannot run on Python 3.9)
- Both `[project.optional-dependencies]` and `[tool.poetry.dev-dependencies]` are now in sync

## pylint 4.0 breaking changes - migration assessment

| Breaking change | Impact on this repo |
|---|---|
| `suggestion-mode` option removed | No `.pylintrc` / `[tool.pylint]` in project - no action needed |
| `invalid-name` reassignment behavior changed | No pylint config to update; CI does not run pylint |
| `async.py` checker renamed to `async_checker.py` | Project does not extend pylint checkers - not applicable |
| `continue-in-finally` message ID `E0116` -> `W0136` | No inline `# pylint: disable=E0116` comments in codebase |
| `isort` requirement bumped to `>=5.0.0` | Already satisfied: project uses `isort >=5.12.0` / `^8.0.0` |
| Removed Python 3.9 launcher support | Handled by keeping `pylint <4.0.0` for Python 3.9 |

**No code migration is required** - pylint is a dev-only tool, CI does not run pylint linting, and none of the removed options are used in this project.

## References

- Supersedes #178 (renovate bot PR with broken Python 3.9 constraint)
- pylint 4.0 release notes: https://pylint.readthedocs.io/en/latest/whatsnew/4/4.0/index.html
- pylint 4.0.5 on PyPI (confirms `requires_python >= 3.10.0`): https://pypi.org/project/pylint/4.0.5/