### PR TITLE
chore(deps): guard against re-breaking django pin for Python &lt;3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `>=4.2.0,<5.0.0` pin for `python_version < "3.12"` is intentional; the same breaking
   bump was already rejected once in PR #198 and recurred in PR #200.
 
+## [2.4.0] - 2026-08-20
+
+### Added
+- **Management client**: Regenerated from the latest OpenAPI spec, adding the `directories_api`
+  and `environments_api` namespaces, plus expanded `organizations_api`, `roles_api`, `users_api`
+  and `applications_api` surfaces (including application access roles and billing customer
+  endpoints/models)
+
+### Improved
+- **Documentation**: Refreshed `README_management_client.md` examples to use the namespaced
+  management client accessors (e.g. `client.users_api.get_users()`,
+  `client.environments_api.get_environement_feature_flags()`) instead of the flattened,
+  deprecated top-level methods
+- **CI**: Bumped `actions/setup-python` to v7
+
 ## [2.3.1] - 2026-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Kinde Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **CI**: Hardened `renovate.json` so Renovate can no longer re-propose bumping the Python
+  `<3.12` `django` pin in `requirements.txt` to Django 6.x (Django 6.0+ requires Python
+  3.12+). Django is a test-only dependency for this SDK (no runtime usage), and the
+  `>=4.2.0,<5.0.0` pin for `python_version < "3.12"` is intentional; the same breaking
+  bump was already rejected once in PR #198 and recurred in PR #200.
+
 ## [2.3.1] - 2026-07-06
 
 ### Fixed

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Django 6.x dropped support for Python <3.12 (Django only supports 3.12+ as of 6.0). requirements.txt pins django>=4.2.0,<5.0.0 for python_version<3.12 specifically so CI on 3.9-3.11 keeps working; restrict that pin to Django 4.x so Renovate doesn't repeat the breaking django>=6.1 bump for those interpreters (see PR #198 and #200).",
+      "matchManagers": ["pip_requirements"],
+      "matchPackageNames": ["django"],
+      "matchCurrentValue": "/^>=4\\.2\\.0,<5\\.0\\.0$/",
+      "allowedVersions": "<5.0.0"
+    }
   ]
 }


### PR DESCRIPTION
Replaces #200.

## What renovate PR #200 proposed

Bump the `requirements.txt` line `django>=4.2.0,<5.0.0; python_version < "3.12"` to `django>=6.1,<6.2.0; python_version < "3.12"`.

## Why it's unsafe as-is

Django 6.0+ [dropped support for Python < 3.12](https://docs.djangoproject.com/en/6.0/releases/6.0/#python-compatibility) - it only supports 3.12, 3.13, 3.14. Installing `django>=6.1` on Python 3.9/3.10/3.11 fails, which is exactly what broke CI on PR #200 (`unittest (3.10)` failed, other jobs cancelled).

This isn't new: the same breaking bump was already proposed and rejected once before, in #198 (`chore(deps): update dependency django to v6.1` → `fix: scope django 6.1 to supported Python versions`). Renovate re-proposed the identical breaking change in #200 because nothing in `renovate.json` told it the `<3.12` pin was intentional.

Also worth noting: `django` isn't an actual runtime dependency of this SDK (it's not in `pyproject.toml`'s `dependencies`) - it's only used by `pytest-django` for framework-detection tests, so there's no SDK-facing migration needed either way.

## What this PR does instead

- `requirements.txt` is left as-is (already correct/safe: `django>=4.2.0,<5.0.0` for `<3.12`, `django>=6.1,<6.2.0` for `>=3.12`).
- `renovate.json`: added a `packageRules` entry that scopes `allowedVersions: "<5.0.0"` to just the `<3.12` line (matched via `matchCurrentValue`), so Renovate keeps proposing Django 4.2.x patch updates for that line but can't re-suggest the incompatible 6.x bump again. The `>=3.12` line is untouched and keeps getting normal 6.1.x updates.
- `CHANGELOG.md`: documented the decision under `Unreleased`.

## Follow-up

Please close #200 once this merges.
